### PR TITLE
support for command line args

### DIFF
--- a/ReleaseNotesGenerator/CommandLine.fs
+++ b/ReleaseNotesGenerator/CommandLine.fs
@@ -1,0 +1,53 @@
+﻿
+module CommandLine
+
+type CommandLineOptions = {
+    repository: string;
+    token: string;
+    whatif: bool;
+    }
+
+let rec parseCommandLine args optionsSoFar = 
+    match args with 
+    | [] -> 
+        optionsSoFar  
+
+    | "/whatif"::xs -> 
+        let newOptionsSoFar = { optionsSoFar with whatif=true}
+        parseCommandLine xs newOptionsSoFar 
+
+    | "/token"::xs -> 
+        match xs with
+        | x::xss ->
+            if x.StartsWith("/") then
+                eprintfn "Token needs a second argument"
+                parseCommandLine xs optionsSoFar 
+            else 
+                let newOptionsSoFar = { optionsSoFar with token=x}
+                parseCommandLine xss newOptionsSoFar 
+        | [] -> 
+            eprintfn "Token needs a second argument"
+            parseCommandLine xs optionsSoFar 
+        | _ -> 
+            eprintfn "Token needs a second argument"
+            parseCommandLine xs optionsSoFar 
+
+    | "/repo"::xs -> 
+        match xs with
+        | x::xss -> 
+            if x.StartsWith("/") then
+                eprintfn "Repository needs a second argument"
+                parseCommandLine xs optionsSoFar 
+            else 
+                let newOptionsSoFar = { optionsSoFar with repository=x}
+                parseCommandLine xss newOptionsSoFar 
+        | [] -> 
+            eprintfn "Repository needs a second argument"
+            parseCommandLine xs optionsSoFar 
+        | _ -> 
+            eprintfn "Repository needs a second argument"
+            parseCommandLine xs optionsSoFar 
+
+    | x::xs -> 
+        eprintfn "Option '%s' is unrecognized" x
+        parseCommandLine xs optionsSoFar 

--- a/ReleaseNotesGenerator/Program.fs
+++ b/ReleaseNotesGenerator/Program.fs
@@ -6,6 +6,7 @@ open System.Reactive.Linq;
 
 open GitHub
 open Observables
+open CommandLine
 
 let formatSection str items =
     printf "For group '%s':\r\n" str
@@ -23,14 +24,25 @@ let writeSkippedList (items:seq<_>)=
 
 [<EntryPoint>]
 let main argv = 
+
    let token = System.Environment.GetEnvironmentVariable "OCTOKIT_OAUTHTOKEN"
+
+   let defaultOptions = {
+       whatif = false;
+       repository = "";
+       token = token;
+       }
+
+   let argsProcessed = parseCommandLine (Array.toList argv) defaultOptions
+
+   // TODO: be way more cleverer about what we support
+   let index = argsProcessed.repository.IndexOf('/')
+
+   let owner = argsProcessed.repository.Substring(0, index)
+   let name = argsProcessed.repository.Substring (index+1)
+
    let client = ObservableGitHubClient(new ProductHeaderValue("Hermes"))
    client.Connection.Credentials<-Credentials(token)
-
-   // TODO: accept these as arguments
-
-   let owner = "octokit"
-   let name = "octokit.net"
 
    // curried functions
    let resolvePullRequestUsingId =  resolvePullRequest client owner name

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
@@ -25,6 +25,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\ReleaseNotesGenerator.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
+    <StartArguments>/repo octokit/octokit.net</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -55,6 +56,7 @@
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="CommandLine.fs" />
     <Compile Include="Observables.fs" />
     <Compile Include="GitHub.fs" />
     <Compile Include="Program.fs" />


### PR DESCRIPTION
Using [this post](https://fsharpforfunandprofit.com/posts/pattern-matching-command-line/) as a starting point, this adds support for various arguments to be provided to the program.

e.g. `/repo octokit/octokit.net /whatif /token {blah}`

Order doesn't matter, but might have some edge cases here to deal with...