### PR TITLE
Allow specifying different branch name to compare with

### DIFF
--- a/ReleaseNotesGenerator/CommandLine.fs
+++ b/ReleaseNotesGenerator/CommandLine.fs
@@ -5,6 +5,7 @@ type CommandLineOptions = {
     repository: string;
     token: string;
     whatif: bool;
+    branch: string;
     }
 
 let rec parseCommandLine args optionsSoFar = 
@@ -47,7 +48,18 @@ let rec parseCommandLine args optionsSoFar =
         | _ -> 
             eprintfn "Repository needs a second argument"
             parseCommandLine xs optionsSoFar 
-
+    | "/branch"::xs ->
+        match xs with
+        | x::xss -> 
+            if x.StartsWith("/") then
+                eprintfn "branch needs a second argument"
+                parseCommandLine xs optionsSoFar 
+            else 
+                let newOptionsSoFar = { optionsSoFar with branch=x}
+                parseCommandLine xss newOptionsSoFar 
+        | [] -> 
+            eprintfn "branch needs a second argument"
+            parseCommandLine xs optionsSoFar 
     | x::xs -> 
         eprintfn "Option '%s' is unrecognized" x
         parseCommandLine xs optionsSoFar 

--- a/ReleaseNotesGenerator/CommandLine.fs
+++ b/ReleaseNotesGenerator/CommandLine.fs
@@ -29,9 +29,6 @@ let rec parseCommandLine args optionsSoFar =
         | [] -> 
             eprintfn "Token needs a second argument"
             parseCommandLine xs optionsSoFar 
-        | _ -> 
-            eprintfn "Token needs a second argument"
-            parseCommandLine xs optionsSoFar 
 
     | "/repo"::xs -> 
         match xs with
@@ -45,9 +42,7 @@ let rec parseCommandLine args optionsSoFar =
         | [] -> 
             eprintfn "Repository needs a second argument"
             parseCommandLine xs optionsSoFar 
-        | _ -> 
-            eprintfn "Repository needs a second argument"
-            parseCommandLine xs optionsSoFar 
+
     | "/branch"::xs ->
         match xs with
         | x::xss -> 

--- a/ReleaseNotesGenerator/Program.fs
+++ b/ReleaseNotesGenerator/Program.fs
@@ -1,5 +1,4 @@
 ﻿
-
 open Octokit
 open Octokit.Reactive
 open System.Reactive.Linq;
@@ -26,11 +25,12 @@ let writeSkippedList (items:seq<_>)=
 let main argv = 
 
    let token = System.Environment.GetEnvironmentVariable "OCTOKIT_OAUTHTOKEN"
-
+   
    let defaultOptions = {
        whatif = false;
        repository = "";
        token = token;
+       branch = "master"
        }
 
    let argsProcessed = parseCommandLine (Array.toList argv) defaultOptions
@@ -51,7 +51,7 @@ let main argv =
    // the actual heavy-lifting
    let latestRelease = await (client.Repository.Release.GetAll(owner,  name).Take 1)
 
-   let compare = await (client.Repository.Commit.Compare(owner, name, latestRelease.TagName, "master"))
+   let compare = await (client.Repository.Commit.Compare(owner, name, latestRelease.TagName, argsProcessed.branch))
 
    let mergedPullRequests = findMergePullRequests compare
 

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
@@ -25,7 +25,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\ReleaseNotesGenerator.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
-    <StartArguments>/repo octokit/octokit.net</StartArguments>
+    <StartArguments>/repo octokit/octokit.net /branch master</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
+++ b/ReleaseNotesGenerator/ReleaseNotesGenerator.fsproj
@@ -25,7 +25,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\ReleaseNotesGenerator.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
-    <StartArguments>/repo octokit/octokit.net /branch master</StartArguments>
+    <StartArguments>/repo octokit/octokit.net</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Fixes #10

* Added `/branch` parameter with `master` as a default value
* Some unreachable code removed (for list `| xs::xss` and `| []` patterns is enough)